### PR TITLE
chore: cache nim compiler in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache Nim compiler
+        id: cache-nim
+        uses: actions/cache@v4
+        with:
+          path: .nim_runtime
+          key: nim-2.2.6-${{ matrix.os }}-${{ matrix.cpu }}
+
       - name: Install Nim
+        if: steps.cache-nim.outputs.cache-hit != 'true'
         uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: '2.2.6'
+          nim-install-directory: .nim_runtime
+
+      - name: Add Nim to PATH (cache hit)
+        if: steps.cache-nim.outputs.cache-hit == 'true'
+        run: |
+          echo "$PWD/.nim_runtime/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
       - name: Install Dependencies
         run: nimble install -y cligen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,7 @@ jobs:
           nim-version: '2.2.6'
           nim-install-directory: .nim_runtime
 
-      - name: Add Nim to PATH (cache hit)
-        if: steps.cache-nim.outputs.cache-hit == 'true'
+      - name: Add Nim to PATH
         run: |
           echo "$PWD/.nim_runtime/bin" >> "$GITHUB_PATH"
           echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented Nim compiler caching in the release workflow to speed up CI runs.
  * Reuses existing Nim installation on cache hits and installs Nim only when needed.
  * Ensures Nim binaries are added to the environment PATH for subsequent steps, improving consistency and reliability of releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->