### PR TITLE
CI: cache nimble/nim in test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
         with:
           nim-version: '2.2.6'
 
+      - name: Cache Nimble and Nim
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nimble
+            ~/.cache/nim
+          key: ${{ runner.os }}-nim-2.2.6-nimble-${{ hashFiles('nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nim-2.2.6-nimble-
+
       - name: Install Dependencies
         run: nimble install -y --depsOnly
 


### PR DESCRIPTION
## Summary
- add actions/cache for ~/.nimble and ~/.cache/nim
- key cache by OS, Nim version, and nimble.lock

## Testing
- not run (CI only)