### PR TITLE
Fix release CI: generate nimble.paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           nim-version: '2.2.6'
 
       - name: Install Dependencies
-        run: nimble install -y cligen
+        run: nimble install -y --depsOnly
 
       - name: Install Cross-compiler (Linux ARM64 only)
         if: matrix.install_cross != ''


### PR DESCRIPTION
## Summary
- use `nimble install -y --depsOnly` in release workflow so nimble.paths is generated in CI
- removes reliance on local nimble.paths with absolute paths

## Testing
- not run (CI only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to install only declared dependencies, improving build consistency and maintainability of the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->