### PR TITLE
CI: Optimize release workflow with cache and nimble

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache Nimble dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-nimble-${{ hashFiles('nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nimble-
+
       - name: Install Nim
         uses: jiro4989/setup-nim-action@v2
         with:


### PR DESCRIPTION
## Changes
- Use `nimble c` instead of `nim c` for consistent build environment
- Add caching for `~/.nimble` directory to speed up dependencies installation

## Motivation
- Improve build time, especially on macOS runners
- Ensure correct package resolution during release build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow caching for improved release process efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->