### PR TITLE
Add asdf provider detection

### DIFF
--- a/src/why_core.nim
+++ b/src/why_core.nim
@@ -57,6 +57,9 @@ proc defaultRules*(homeDir: string): seq[ProviderRule] =
     ProviderRule(name: "Mise", kind: mkContains, patterns: @[
       "mise/shims", ".local/share/mise"
     ]),
+    ProviderRule(name: "asdf", kind: mkContains, patterns: @[
+      ".asdf/shims", ".asdf/installs"
+    ]),
     ProviderRule(name: "Snap", kind: mkContains, patterns: @[
       "/snap/", "snap/bin"
     ]),

--- a/tests/test_why_core.nim
+++ b/tests/test_why_core.nim
@@ -84,3 +84,12 @@ suite "whyCore":
       rules
     )
     check provider == "System"
+
+  test "asdf shim takes precedence over system path":
+    let rules = defaultRules("/home/test")
+    let provider = detectProviderByPath(
+      "/home/test/.asdf/shims/node",
+      "/usr/bin/node",
+      rules
+    )
+    check provider == "asdf"


### PR DESCRIPTION
## Summary

- add asdf provider detection rule (shims/installs)
- ensure rule precedence before system
- add test for asdf shim precedence

## Testing

- nimble test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for asdf as a provider option, expanding the system's ability to recognize asdf installations in your environment.

* **Tests**
  * Added test case to verify asdf detection works correctly and maintains proper precedence handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->