### PR TITLE
Add Nix flake and Home Manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,48 @@ It resolves symlinks, checks path patterns, and queries system package managers 
 
 ## Installation
 
+### Home Manager (Nix)
+
+Add this repository as a flake input:
+
+```nix
+{
+  inputs.why-cli = {
+    url = "github:akriaueno/why-cli";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+}
+```
+
+Then install it with `home.packages`:
+
+```nix
+{ inputs, pkgs, ... }:
+
+{
+  home.packages = [
+    inputs.why-cli.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}
+```
+
+If your Home Manager modules do not already receive `inputs`, pass them from
+`homeManagerConfiguration` with `extraSpecialArgs = { inherit inputs; };`.
+
+Or import the included Home Manager module:
+
+```nix
+{ inputs, ... }:
+
+{
+  imports = [
+    inputs.why-cli.homeManagerModules.default
+  ];
+
+  programs.why.enable = true;
+}
+```
+
 ### Homebrew (macOS & Linux) - Recommended
 
 You can easily install `why` using Homebrew.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "why - identify why a command is installed on your system";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        why-cli = pkgs.callPackage ./nix/package.nix { };
+      in
+      {
+        packages = {
+          default = why-cli;
+          inherit why-cli;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${why-cli}/bin/why";
+          meta.description = "Run why";
+        };
+      }
+    )
+    // {
+
+      overlays.default = final: _prev: {
+        why-cli = final.callPackage ./nix/package.nix { };
+      };
+
+      homeManagerModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.programs.why;
+        in
+        {
+          options.programs.why = {
+            enable = lib.mkEnableOption "why, a CLI for identifying command installation sources";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              defaultText = lib.literalExpression "inputs.why-cli.packages.\${pkgs.stdenv.hostPlatform.system}.default";
+              description = "The why package to install.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+          };
+        };
+    };
+}

--- a/nix/nim-lock.json
+++ b/nix/nim-lock.json
@@ -1,0 +1,16 @@
+{
+  "depends": [
+    {
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "method": "git",
+      "packages": [
+        "cligen"
+      ],
+      "rev": "f082560a4bbd4afa1b35e9810b291d17c265b666",
+      "sha256": "0s6nfvwmc36c9w55k3d0m3gbnm6hiwxnqqz11pjdq41ixnzx4crz",
+      "srcDir": ".",
+      "url": "https://github.com/c-blake/cligen.git"
+    }
+  ]
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  buildNimPackage,
+}:
+
+buildNimPackage {
+  pname = "why-cli";
+  version = "0.1.0";
+
+  src = lib.cleanSource ../.;
+  lockFile = ./nim-lock.json;
+
+  meta = {
+    description = "Tells you why a command is installed on your system";
+    homepage = "https://github.com/akriaueno/why-cli";
+    license = lib.licenses.mit;
+    mainProgram = "why";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary
- Add a Nix flake that exposes `why-cli` as a package, app, and overlay
- Add a Home Manager module with `programs.why.enable`
- Use `flake-utils.lib.eachDefaultSystem` for standard system iteration
- Document Home Manager installation through `home.packages` and the module import path

## Testing
- `nix build .#why-cli --no-link`
- `nix run . -- --help`
- `nix flake check --all-systems`
- Built a temporary Home Manager activation package with `programs.why.enable = true`
