### PR TITLE
chore: update GitHub Actions pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,32 +20,30 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: clippy, rustfmt
+        run: rustup toolchain install stable --profile minimal --component clippy --component rustfmt
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check Formatting
-        run: cargo fmt --check
+        run: cargo +stable fmt --check
 
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo +stable clippy --all-targets -- -D warnings
 
       - name: Run Tests
-        run: cargo test --locked
+        run: cargo +stable test --locked
 
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -57,12 +55,12 @@ jobs:
   nix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Build Nix Package
         run: nix build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,17 +45,15 @@ jobs:
             linker_env: ''
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: ${{ matrix.target }}
+        run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: "false"
 
@@ -66,14 +64,14 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          ${{ matrix.linker_env }} cargo build --release --locked --target ${{ matrix.target }}
+          ${{ matrix.linker_env }} cargo +stable build --release --locked --target ${{ matrix.target }}
           cp target/${{ matrix.target }}/release/why ${{ matrix.archive_name }}
 
       - name: Create Archive
         run: tar czf ${{ matrix.archive_name }}.tar.gz ${{ matrix.archive_name }}
 
       - name: Release to GitHub
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ${{ matrix.archive_name }}.tar.gz
@@ -86,12 +84,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')
     steps:
       - name: Checkout why-cli repository (for scripts)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Checkout tap repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: akriaueno/homebrew-tap
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
@@ -132,7 +130,7 @@ jobs:
           echo "========================="
 
       - name: Create PR on tap repository
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }} # fine-grained PAT (homebrew-tap, contents:write & pull-requests:write)
           path: homebrew-tap


### PR DESCRIPTION
## Summary
- update pinned GitHub Actions to their latest semver releases while keeping SHA pinning
- move Rust setup from `dtolnay/rust-toolchain` to official `rustup` commands
- update action comments from major-only labels to full semver labels

## Testing
- `cargo +stable fmt --check`
- `cargo +stable clippy --all-targets -- -D warnings`
- `cargo +stable test --locked`
- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml .github/workflows/release.yml`

## Notes
- `softprops/action-gh-release@v3.0.0` uses Node 24, addressing the Node.js 20 deprecation warning.
