### PR TITLE
feat: set CLI version to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Run Tests
         run: cargo +stable test --locked
 
+      - name: Check CLI Version
+        shell: bash
+        run: |
+          expected="why $(cargo +stable metadata --locked --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          actual="$(cargo +stable run --locked -- --version)"
+          test "$actual" = "$expected"
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,16 @@ jobs:
         with:
           save-if: "false"
 
+      - name: Verify Release Version
+        shell: bash
+        run: |
+          crate_version="$(cargo +stable metadata --locked --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$crate_version" != "$tag_version" ]; then
+            echo "Release tag v${tag_version} does not match Cargo.toml version ${crate_version}" >&2
+            exit 1
+          fi
+
       - name: Install Cross-compiler (Linux ARM64 only)
         if: matrix.install_cross != ''
         run: ${{ matrix.install_cross }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "why-cli"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "why-cli"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["akira ueno"]
 description = "Tells you why a command is installed on your system."

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,7 +5,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "why-cli";
-  version = "0.1.0";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
 
   src = lib.cleanSource ../.;
   cargoLock.lockFile = ../Cargo.lock;


### PR DESCRIPTION
## Summary
- bump the crate version to `0.3.0` so `why --version` reports the intended next release version
- make the Nix package read its version from `Cargo.toml`
- add CI checks for CLI version output and release tag/package version mismatch

## Testing
- `cargo +stable test --locked` — 16 passed
- CI version check command — `expected=why 0.3.0`, `actual=why 0.3.0`
- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml .github/workflows/release.yml`
- `nix build && ./result/bin/why --version` — `why 0.3.0`
